### PR TITLE
Integrate SonarQube scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,8 @@ jobs:
         run: npm install --prefix shop-app
       - name: Build
         run: npm run build --prefix shop-app
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v2
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/README.md
+++ b/README.md
@@ -5,5 +5,7 @@ This repository contains a minimal Angular application located in `shop-app`.
 ## Continuous Integration
 
 GitHub Actions automatically install dependencies and build the project on every push or pull request to `main`.
+The workflow also runs a SonarQube scan. Configure `SONAR_TOKEN` and
+`SONAR_HOST_URL` secrets in your repository to enable code analysis.
 
 # personal-project

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+sonar.projectKey=shop-app
+sonar.sources=shop-app/src
+sonar.exclusions=**/*.spec.ts
+sonar.typescript.tsconfigPath=shop-app/tsconfig.app.json


### PR DESCRIPTION
## Summary
- update CI workflow to run SonarQube scan
- add sonar-project.properties configuration
- document SonarQube in README

## Testing
- `npm run build --prefix shop-app` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b84e366483219e55d6335662dcd5