### PR TITLE
Update Node version to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: Install dependencies
         run: npm install --prefix shop-app
       - name: Build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: Install dependencies
         run: npm install --prefix shop-app
       - name: Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 This repository contains a minimal Angular application located in `shop-app`.
 
+## Prerequisites
+
+The application requires **Node.js 22** or later. Install it from
+[nodejs.org](https://nodejs.org/) before running the scripts or workflows.
+
 ## Continuous Integration
 
 GitHub Actions automatically install dependencies and build the project on every


### PR DESCRIPTION
## Summary
- bump Node version to 22 in CI workflow
- bump Node version to 22 in GitHub Pages workflow
- document Node.js 22 requirement

## Testing
- `npm test --prefix shop-app` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bf7e07f083219b1f3e339c7fa8d9