### PR TITLE
Add builder configs to angular.json

### DIFF
--- a/shop-app/angular.json
+++ b/shop-app/angular.json
@@ -11,6 +11,7 @@
       "prefix": "app",
       "architect": {
         "build": {
+          "builder": "@angular-devkit/build-angular:browser",
           "options": {
             "outputPath": "dist/shop-app",
             "index": "src/index.html",
@@ -28,6 +29,7 @@
           }
         },
         "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
             "browserTarget": "shop-app:build"
           }


### PR DESCRIPTION
## Summary
- set `builder` for Angular build and serve targets

## Testing
- `npm run build --prefix shop-app` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c291707c832195d3c29af9a0b602