### PR TITLE
Fix standalone component build error

### DIFF
--- a/shop-app/src/app/app.module.ts
+++ b/shop-app/src/app/app.module.ts
@@ -10,8 +10,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  declarations: [AppComponent, ProductListComponent],
-  imports: [BrowserModule, RouterModule.forRoot(routes)],
+  imports: [BrowserModule, AppComponent, ProductListComponent, RouterModule.forRoot(routes)],
   bootstrap: [AppComponent]
 })
 export class AppModule {}


### PR DESCRIPTION
## Summary
- load `AppComponent` and `ProductListComponent` via the module `imports` array

## Testing
- `npm run build --prefix shop-app` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c52ee6688321b19a9b2d4df519ec