### PR TITLE
Fix tests by including polyfills

### DIFF
--- a/shop-app/tsconfig.spec.json
+++ b/shop-app/tsconfig.spec.json
@@ -5,7 +5,8 @@
     "types": ["jasmine"]
   },
   "files": [
-    "src/test.ts"
+    "src/test.ts",
+    "src/polyfills.ts"
   ],
   "include": [
     "src/**/*.spec.ts",


### PR DESCRIPTION
## Summary
- add `src/polyfills.ts` to `tsconfig.spec.json` so Angular tests compile

## Testing
- `npm test --prefix shop-app` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854df4bd13083219d0dc82decd38f15