### PR TITLE
Fix GitHub Pages path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,15 +27,30 @@ jobs:
         run: npm install --prefix shop-app
 
       - name: Build Angular app
-        run: npm run build --prefix shop-app -- --base-href /personal-project/
+        run: npm run build --prefix shop-app -- --base-href /personal-project/ --output-path dist/personal-project
 
       - name: Create .nojekyll file
-        run: echo "" > shop-app/dist/shop-app/.nojekyll
+        run: echo "" > shop-app/dist/.nojekyll
+
+      - name: Create redirect index.html
+        run: |
+          cat <<'EOF' > shop-app/dist/index.html
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta http-equiv="refresh" content="0; url=./personal-project/">
+            <title>Redirecting...</title>
+          </head>
+          <body>
+            <p>If you are not redirected automatically, follow this <a href="./personal-project/">link</a>.</p>
+          </body>
+          </html>
+          EOF
 
       - name: Upload artifact to GitHub Pages
         uses: actions/upload-pages-artifact@v2
         with:
-          path: shop-app/dist/shop-app
+          path: shop-app/dist
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ enable code analysis.
 ## GitHub Pages Deployment
 
 The project is automatically deployed to GitHub Pages from the `main` branch.
-After each successful build, the production files located in
-`shop-app/dist/shop-app` are published to the `gh-pages` branch. You can view
-the site at `https://<username>.github.io/personal-project/` once GitHub Pages
-is enabled in the repository settings.
+After each successful build, the production files are published to the
+`gh-pages` branch inside a `/personal-project/` folder. Visiting
+`https://<username>.github.io/` will redirect to
+`https://<username>.github.io/personal-project/` once GitHub Pages is enabled in
+the repository settings.
 
 # personal-project

--- a/shop-app/README.md
+++ b/shop-app/README.md
@@ -20,4 +20,4 @@ The application will be available at `http://localhost:4200`.
 
 ## GitHub Pages
 
-A production build is automatically deployed to GitHub Pages from the `main` branch. Visit `https://<username>.github.io/personal-project/` after enabling GitHub Pages in the repository settings.
+A production build is automatically deployed to GitHub Pages from the `main` branch. The site is available at `https://<username>.github.io/personal-project/` (the root URL will redirect to this location) after enabling GitHub Pages in the repository settings.


### PR DESCRIPTION
## Summary
- fix GitHub Pages workflow so built app lives in `/personal-project/`
- document redirect in README files

## Testing
- `npm test --prefix shop-app` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685578c0ea708321babca6fd002ec0b4