### PR TITLE
Fix Angular test

### DIFF
--- a/shop-app/src/app/app.component.spec.ts
+++ b/shop-app/src/app/app.component.spec.ts
@@ -4,7 +4,7 @@ import { AppComponent } from './app.component';
 describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [AppComponent]
+      imports: [AppComponent]
     });
   });
 


### PR DESCRIPTION
## Summary
- fix AppComponent test to use `imports` for standalone component

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557cd7e73483219bd06f58f48c83f6