### PR TITLE
Skip sonar scan when secrets absent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Test
         run: npm test --prefix shop-app
       - name: SonarQube Scan
+        if: ${{ secrets.SONAR_TOKEN != '' && secrets.SONAR_HOST_URL != '' }}
         uses: SonarSource/sonarqube-scan-action@v2
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@ This repository contains a minimal Angular application located in `shop-app`.
 ## Continuous Integration
 
 GitHub Actions automatically install dependencies and build the project on every
- push or pull request to `main`. The workflow also runs a SonarQube scan.
-Configure `SONAR_TOKEN` and `SONAR_HOST_URL` secrets in your repository to
-enable code analysis.
+ push or pull request to `main`. The workflow also runs a SonarQube scan if the
+ required secrets are available. Configure `SONAR_TOKEN` and
+ `SONAR_HOST_URL` secrets in your repository to enable code analysis. When these
+ secrets are not set, the scan step is skipped so the rest of the CI workflow
+ can complete successfully.
 
 ## GitHub Pages Deployment
 


### PR DESCRIPTION
## Summary
- handle missing SonarQube secrets in CI workflow
- clarify SonarQube secrets in README

## Testing
- `npm test --prefix shop-app` *(fails: `ng: not found`)*
- `npm install --prefix shop-app` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68557dc207c08321adbcb9744499cfcb