### PR TITLE
Enable test coverage for SonarQube

### DIFF
--- a/shop-app/karma.conf.js
+++ b/shop-app/karma.conf.js
@@ -14,7 +14,11 @@ module.exports = function (config) {
     coverageReporter: {
       dir: require('path').join(__dirname, './coverage'),
       subdir: '.',
-      reporters: [{ type: 'html' }, { type: 'text-summary' }],
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' },
+        { type: 'lcovonly', file: 'lcov.info' },
+      ],
     },
     reporters: ['progress', 'coverage'],
     port: 9876,


### PR DESCRIPTION
## Summary
- generate `lcov.info` in Karma config so that SonarQube can pick up test coverage

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e90c091883218c4733aaea82a78c