### PR TITLE
Add SonarQube coverage details

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
         run: npm install --prefix shop-app
       - name: Build
         run: npm run build --prefix shop-app
-      - name: Test
+      - name: Test and coverage
         run: npm test --prefix shop-app
       - name: SonarQube Scan
         if: ${{ secrets.SONAR_TOKEN != '' && secrets.SONAR_HOST_URL != '' }}
-        uses: SonarSource/sonarqube-scan-action@v2
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/README.md
+++ b/README.md
@@ -18,4 +18,9 @@ After each successful build, the production files are published to the
 `https://<username>.github.io/personal-project/` once GitHub Pages is enabled in
 the repository settings.
 
-# personal-project
+
+## Test Coverage
+
+Unit tests run during the CI workflow using Angular's Karma test runner. Coverage reports are written to `shop-app/coverage/lcov.info` and uploaded to SonarQube using the `sonar.javascript.lcov.reportPaths` setting in `sonar-project.properties`.
+
+If you use SonarCloud, disable automatic analysis and rely on the CI-based scan to see coverage results.


### PR DESCRIPTION
## Summary
- document how coverage is collected for SonarQube
- highlight coverage in the CI job
- use the latest SonarQube scan GitHub Action

## Testing
- `npm test --prefix shop-app` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ed700cb8832191e814003f88ca6d